### PR TITLE
Fix import name in iOS Swift documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ cargo build --release
 ### Swift (iOS)
 
 ```swift
-import vss_rust_client_ffi
+import VssRustClientFfi
 
 let mnemonic = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about"
 let passphrase: String? = nil


### PR DESCRIPTION
Fixes the import package name in iOS Swift documentations in the README