### PR TITLE
ci: add mobile bindgen validation workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,77 @@
+name: Android Bindgen
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to build"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  android-bindgen:
+    name: Android Bindgen
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: "17"
+          distribution: temurin
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config protobuf-compiler zip unzip
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Set up Android NDK
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r28c
+          add-to-path: true
+
+      - name: Export Android NDK root
+        run: echo "ANDROID_NDK_ROOT=${{ steps.setup-ndk.outputs.ndk-path }}" >> "$GITHUB_ENV"
+
+      - name: Generate Android bindings and artifacts
+        run: ./build_android.sh
+
+      - name: Verify Android outputs
+        run: |
+          test -f bindings/android/src/main/kotlin/com/synonym/vssclient/vss_rust_client_ffi.kt
+          test -f bindings/android/src/main/jniLibs/arm64-v8a/libvss_rust_client_ffi.so
+          test -f bindings/android/src/main/jniLibs/armeabi-v7a/libvss_rust_client_ffi.so
+          test -f bindings/android/src/main/jniLibs/x86/libvss_rust_client_ffi.so
+          test -f bindings/android/src/main/jniLibs/x86_64/libvss_rust_client_ffi.so
+          test -f bindings/android/native-debug-symbols.zip
+
+      - name: Upload Android generated outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: vss-android-bindgen
+          path: |
+            bindings/android/src/main/kotlin/com/synonym/vssclient/vss_rust_client_ffi.kt
+            bindings/android/src/main/jniLibs/**/libvss_rust_client_ffi.so
+            bindings/android/native-debug-symbols.zip
+          if-no-files-found: error

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,58 @@
+name: iOS Bindgen
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to build"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  ios-bindgen:
+    name: iOS Bindgen
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Validate Swift package manifest
+        run: swift package dump-package
+
+      - name: Generate iOS bindings and artifacts
+        run: ./build_ios.sh
+
+      - name: Verify iOS outputs
+        run: |
+          test -f bindings/ios/vss_rust_client_ffi.swift
+          test -f bindings/ios/vss_rust_client_ffiFFI.h
+          test -f bindings/ios/module.modulemap
+          test -d bindings/ios/VssRustClientFfi.xcframework
+          test -f bindings/ios/VssRustClientFfi.xcframework.zip
+          swift package compute-checksum bindings/ios/VssRustClientFfi.xcframework.zip
+
+      - name: Upload iOS generated outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: vss-ios-bindgen
+          path: |
+            bindings/ios/vss_rust_client_ffi.swift
+            bindings/ios/vss_rust_client_ffiFFI.h
+            bindings/ios/module.modulemap
+            bindings/ios/VssRustClientFfi.xcframework
+            bindings/ios/VssRustClientFfi.xcframework.zip
+          if-no-files-found: error

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,0 +1,43 @@
+name: Validation
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: Validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config protobuf-compiler
+
+      - name: Check shell scripts
+        run: bash -n build.sh build_ios.sh build_android.sh build_python.sh
+
+      - name: Check Rust package
+        run: cargo check --locked
+
+      - name: Run Rust tests
+        run: cargo test --locked
+
+      - name: Run Clippy
+        run: cargo clippy --locked --all-targets


### PR DESCRIPTION
## Summary

- Add CI validation for Rust, shell scripts, and Clippy
- Add Android bindgen workflow that generates Kotlin/JNI artifacts on Ubuntu
- Add iOS bindgen workflow that generates Swift/XCFramework artifacts on macOS
- Upload generated mobile artifacts for inspection

## Details

This is Phase 1 of moving mobile bindgen/release work into GitHub Actions.

The new workflows keep permissions read-only and do not publish packages, upload release assets, or remove any checked-in generated files. They only prove that Android and iOS generated outputs can be produced from source in CI.

See https://github.com/synonymdev/bitkit-core/issues/114

## Testing

Locally ran:

```bash
bash -n build.sh build_ios.sh build_android.sh build_python.sh